### PR TITLE
feat: prevent publishing empty resumes with validation toast

### DIFF
--- a/src/components/PublishButton.tsx
+++ b/src/components/PublishButton.tsx
@@ -42,8 +42,27 @@ export const PublishButton = ({ resumeData, existingId, onPublished, keyProp }: 
     return match ? decodeURIComponent(match[1]) : null;
   }
 
+  // Helper function to check if form has any meaningful data
+  const isFormEmpty = () => {
+    return !(resumeData.firstName || resumeData.lastName || resumeData.email || 
+             resumeData.phone || resumeData.summary || resumeData.experiences.length > 0 || 
+             resumeData.education.length > 0 || resumeData.skills.length > 0 ||
+             resumeData.certifications.length > 0 || resumeData.languages.length > 0 ||
+             resumeData.customSections.length > 0);
+  };
+
   const handlePublish = async () => {
     try {
+      // Check if form is empty (showing dummy data)
+      if (isFormEmpty()) {
+        toast({
+          title: "Resume is empty",
+          description: "Fill out the form to publish your resume. The preview shows sample data - start adding your own details!",
+          variant: "destructive",
+        });
+        return;
+      }
+
       // Pre-validation checks
       const validation = validateResumeData(resumeData);
       if (!validation.isValid) {


### PR DESCRIPTION
- Add isFormEmpty() validation in PublishButton component
- Check all form fields (personal info, experience, education, skills, etc.)
- Show user-friendly toast message when form is empty
- Prevent accidental publishing of sample/dummy data
- Maintain existing validation flow for filled forms

# Pull Request

## Description
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Fixes # (issue)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe):

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context 